### PR TITLE
FIX: bibtex export

### DIFF
--- a/app/utils/bibtex_exporter.rb
+++ b/app/utils/bibtex_exporter.rb
@@ -43,8 +43,6 @@ class BibtexExporter
       &.filter { |creator| creator.relationships != ["edt"] }
       &.map(&:name)
       &.join(" and ")
-
-
   end
 
   def self.parse_editor(record, bibtex_representation)

--- a/app/utils/bibtex_exporter.rb
+++ b/app/utils/bibtex_exporter.rb
@@ -17,6 +17,7 @@ class BibtexExporter
 
       # more complex mappings
       parse_author      record, bibtex_representation
+      parse_editor      record, bibtex_representation
       parse_identifiers record, bibtex_representation
       parse_series      record, bibtex_representation
       parse_type        record, bibtex_representation
@@ -39,6 +40,19 @@ class BibtexExporter
     bibtex_representation["author"] =
       record.creators
       .presence
+      &.filter { |creator| creator.relationships != ["edt"] }
+      &.map(&:name)
+      &.join(" and ")
+
+
+  end
+
+  def self.parse_editor(record, bibtex_representation)
+
+    bibtex_representation["editor"] =
+      record.creators
+      .presence
+      &.filter { |creator| creator.relationships.include?("edt") }
       &.map(&:name)
       &.join(" and ")
   end


### PR DESCRIPTION
creators of a record with only a editor relationship are now exported as editors in bibtex and excluded from the authors list. If there is another relationship they are still listed as authors